### PR TITLE
Supporting Kaifa 304 additional properties

### DIFF
--- a/Logger.cpp
+++ b/Logger.cpp
@@ -1,0 +1,29 @@
+#include "Logger.h"
+#include "Settings.h"
+
+// Create Wifi Connector
+Logger::Logger(String name)
+{
+  _name = name;
+}
+
+void Logger::debug(String msg)
+{
+  if (LOG_LEVEL <= DEBUG) {
+    Serial.println("DEBUG - " + _name + ":" + msg);
+  }
+}
+
+void Logger::info(String msg)
+{
+  if (LOG_LEVEL <= INFO) {
+    Serial.println("INFO - " + _name + ":" + msg);
+  }
+}
+
+void Logger::warn(String msg)
+{
+  if (LOG_LEVEL <= WARN) {
+    Serial.println("WARN - " + _name + ":" + msg);
+  }
+}

--- a/Logger.h
+++ b/Logger.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <Arduino.h>
+
+class Logger
+{
+  private:
+    String _name;
+
+  public:
+    Logger(String name = "Logger");
+    void info(String msg);
+    void debug(String msg);
+    void warn(String msg);
+};

--- a/MQTTPublisher.h
+++ b/MQTTPublisher.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include "PubSubClient.h"
 #include "WiFiClient.h"
+#include "Logger.h"
 
 #define RECONNECT_TIMEOUT 15000
 
@@ -14,20 +15,23 @@ extern bool hasWIFI;
 class MQTTPublisher
 {
   private:
-    bool debugMode;
+    Logger logger;
+    bool _debugMode;
+    String _clientId;
     bool isStarted;
 
     uint32_t lastConnectionAttempt = 0; // last reconnect
     uint32_t lastUpdateMqtt; // last data send
    
     bool reconnect();
+    String getTopic(String name);
   public:
-    MQTTPublisher(bool inDebugMode = false);
+    MQTTPublisher(String clientId = String(ESP.getChipId(), HEX));
     ~MQTTPublisher();
 
     void start();
     void stop();
 
     void handle();
-    bool publishOnMQTT(String prepend, String topic, String value);
+    bool publishOnMQTT(String topic, String msg);
 };

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # esp8266-dsmr
+
+> 16-04-2020: Based on Bram2202's [esp8266-dsmr](https://github.com/bram2202/esp8266-dsmr).
+> - Extended number of supported properties to include all property values send by a [Kaifa 304](https://www.liander.nl/sites/default/files/Meters-Handleidingen-elektriciteit-Kaifa-uitgebreid.pdf) smart meter. Now in a simple structure and easy to extend.
+> - Changed MQTT structure to `esp-dsmr/<device-id>/<property-name>`. The property name can include additional `/`. E.g. for `1-0:31.7.0` (L1 instant usage), the MQTT topic is `esp-dsmr/<device-id>/power/phase_1/instant_usage`.
+> 
+> See [code](https://github.com/diversit/esp8266-dsmr/blob/master/esp8266-dsmr.ino#L28) for all supported properties.
+
+
 A ESP8266 based DSMR reader, posting onto MQTT, powered directly from the meter itself, no external power supply needed..
 
 All units (except power tariff and version) are rounded to 3 decimals.

--- a/Settings.example.h
+++ b/Settings.example.h
@@ -26,4 +26,7 @@
 #define MQTT_TOPIC "dsmr"
 
 //for debugging, print info on serial
-#define DEBUGE_MODE true
+#define DEBUG 1
+#define INFO  2
+#define WARN  3
+#define LOG_LEVEL DEBUG

--- a/WifiConnector.cpp
+++ b/WifiConnector.cpp
@@ -7,9 +7,9 @@
 #include "ESP8266mDNS.h"
 
 // Create Wifi Connector
-WifiConnector::WifiConnector(bool inDebugMode)
+WifiConnector::WifiConnector()
 {
-  debugMode = inDebugMode;
+  logger = Logger("WifiConnector");
   tryingReconnect = false;
 }
 
@@ -17,9 +17,7 @@ WifiConnector::WifiConnector(bool inDebugMode)
 void WifiConnector::start()
 {
 
-  if (debugMode){ 
-    Serial.println("Wifi) Start ");
-  }
+  logger.info("Start");
 
   // Setup Wifi
   WiFi.mode(WIFI_STA);
@@ -30,30 +28,21 @@ void WifiConnector::start()
   // Wait until unit has wifi before continuing
   while (WiFi.status() != WL_CONNECTED) {
       delay(500);
-      if (debugMode){
-        Serial.print(".");
-      }
+      logger.debug(".");
   }
 
   // Set wifi bool
   hasWIFI = true;
 
-  if (debugMode)
-  {
-    Serial.println("Wifi) Connected!");
-    Serial.println("Wifi) IP: ");
-    Serial.println(WiFi.localIP());
-  }
-
+  logger.info("Connected!");
+  logger.debug("IP: " + WiFi.localIP());
 }
 
 // If wifi connection is lost, try to reconnect
 void WifiConnector::reconnect()
 {
 
-  if (debugMode){
-    Serial.println("Wifi) Try to reconnect!");
-  }
+  logger.debug("Try to reconnect!");
   
   // First hit, try to reconnect. 
   if(!tryingReconnect)
@@ -71,9 +60,7 @@ void WifiConnector::handle()
   // Check if WIfi is Connected
   if(!WiFi.isConnected() && !tryingReconnect){
         
-    if (debugMode){
-      Serial.println("Wifi) Disconnected!");
-    }
+    logger.info("Disconnected!");
 
     // Set bool false and try to reconnect
     hasWIFI = false;
@@ -81,13 +68,9 @@ void WifiConnector::handle()
  
   }else if (WiFi.isConnected() && !hasWIFI){ // Wifi is Reconnected
 
-    if (debugMode){
-      Serial.println("Wifi) Reconnected!");
-    }
+    logger.info("Reconnected!");
 
     hasWIFI = true;
     tryingReconnect = false;
-
   }
-        
 }

--- a/WifiConnector.h
+++ b/WifiConnector.h
@@ -1,15 +1,16 @@
 #pragma once
+#include "Logger.h"
 
 extern bool hasWIFI;
 
 class WifiConnector
 {
   private:
-    bool debugMode;
+    Logger logger;
     bool tryingReconnect;
 
   public:
-    WifiConnector(bool inDebugMode = false);
+    WifiConnector();
     void start();
     void handle();
     void reconnect();

--- a/esp8266-dsmr.ino
+++ b/esp8266-dsmr.ino
@@ -6,13 +6,105 @@
 #include "WifiConnector.h"
 #include "ESP8266mDNS.h"
 #include "Settings.h"
+#include "Logger.h"
 
-MQTTPublisher mqqtPublisher(DEBUGE_MODE);
-WifiConnector wifiConnector(DEBUGE_MODE);
+//enum ValueType { STRING, FLOAT }
+
+typedef struct {
+  String name;
+  String key; // OBIS property key
+  int start; // start of value in string
+  int end;   // end  of value in string
+
+  enum {
+    STRING,
+    FLOAT,
+    INT
+  } valueType;
+  
+} Measurement;
+
+const Measurement measurements[] = {
+  { "version"                        , "1-3:0.2.8"  , 10, 12, Measurement::STRING },
+  { "power/timestamp"                , "0-0:1.0.0"  , 10, 23, Measurement::STRING },
+  { "power/device_id"                , "0-0:96.1.1" , 11, 45, Measurement::STRING },
+  { "power/power_consuption"         , "1-0:1.7.0"  , 10, 16, Measurement::FLOAT },
+  { "power/power_production"         , "1-0:2.7.0"  , 10, 16, Measurement::FLOAT },
+  { "power/total_consuption_low"     , "1-0:1.8.1"  , 10, 20, Measurement::FLOAT },
+  { "power/total_consuption_high"    , "1-0:1.8.2"  , 10, 20, Measurement::FLOAT },
+  { "power/total_production_low"     , "1-0:2.8.1"  , 10, 20, Measurement::FLOAT },
+  { "power/total_production_high"    , "1-0:2.8.2"  , 10, 20, Measurement::FLOAT },
+  { "gas/total"                      , "0-1:24.2.1" , 26, 35, Measurement::FLOAT },
+  { "power/power_tariff"             , "0-0:96.14.0", 12, 16, Measurement::INT},
+  // Additional properties as available on Kaifa 304
+  // specs: https://www.netbeheernederland.nl/_upload/Files/Slimme_meter_15_a727fce1f1.pdf
+  // Kaifa: https://www.liander.nl/sites/default/files/Meters-Handleidingen-elektriciteit-Kaifa-uitgebreid.pdf  
+  { "power/short_power_outages"      , "0-0:96.7.21", 12, 17, Measurement::INT },
+  { "power/long_power_outages"       , "0-0:96.7.9" , 11, 16, Measurement::INT },
+  { "power/phase_1/short_power_drops", "1-0:32.32.0", 12, 17, Measurement::INT },
+  { "power/phase_2/short_power_drops", "1-0:52.32.0", 12, 17, Measurement::INT },
+  { "power/phase_3/short_power_drops", "1-0:72.32.0", 12, 17, Measurement::INT },
+  { "power/phase_1/short_power_peaks", "1-0:32.36.0", 12, 17, Measurement::INT },
+  { "power/phase_2/short_power_peaks", "1-0:52.36.0", 12, 17, Measurement::INT },
+  { "power/phase_3/short_power_peaks", "1-0:72.36.0", 12, 17, Measurement::INT },
+  { "power/phase_1/instant_current"  , "1-0:31.7.0" , 11, 14, Measurement::INT },
+  { "power/phase_2/instant_current"  , "1-0:51.7.0" , 11, 14, Measurement::INT },
+  { "power/phase_3/instant_current"  , "1-0:71.7.0" , 11, 14, Measurement::INT },
+  { "power/phase_1/instant_usage"    , "1-0:21.7.0" , 11, 17, Measurement::FLOAT },
+  { "power/phase_2/instant_usage"    , "1-0:41.7.0" , 11, 17, Measurement::FLOAT },
+  { "power/phase_3/instant_usage"    , "1-0:61.7.0" , 11, 17, Measurement::FLOAT },
+  { "power/phase_1/instant_delivery" , "1-0:22.7.0" , 11, 17, Measurement::FLOAT },
+  { "power/phase_2/instant_delivery" , "1-0:42.7.0" , 11, 17, Measurement::FLOAT },
+  { "power/phase_3/instant_delivery" , "1-0:62.7.0" , 11, 17, Measurement::FLOAT },
+  { "gas/device_id"                  , "0-1:96.1.0" , 11, 45, Measurement::STRING },
+  { "gas/timestamp"                  , "0-1:24.2.1" , 11, 24, Measurement::STRING },
+};
+
+MQTTPublisher mqttPublisher;
+WifiConnector wifiConnector;
 WiFiUDP ntpUDP;
 String incomingString = "";
 bool hasMQTT = false;
 bool hasWIFI = false;
+Logger logger = Logger("App");
+
+void test() {
+  handleString("/KFM5KAIFA-METER");
+  handleString("1-3:0.2.8(42)");
+  handleString("0-0:1.0.0(210413140243S)");
+  handleString("0-0:96.1.1(4530303033303030303036343035333134)");
+  handleString("1-0:1.8.1(019867.385*kWh)");
+  handleString("1-0:1.8.2(010090.200*kWh)");
+  handleString("1-0:2.8.1(003899.380*kWh)");
+  handleString("1-0:2.8.2(009033.210*kWh)");
+  handleString("0-0:96.14.0(0002)");
+  handleString("1-0:1.7.0(00.708*kW)");
+  handleString("1-0:2.7.0(00.001*kW)");
+  handleString("0-0:96.7.21(00012)");
+  handleString("0-0:96.7.9(00006)");
+  handleString("1-0:99.97.0(5)(0-0:96.7.19)(181227144100W)(0000020430*s)(181219144343W)(0000021625*s)(161123070756W)(0000001349*s)(151126025422W)(0000004263*s)(000101000001W)(2147483647*s)");
+  handleString("1-0:32.32.0(00001)");
+  handleString("1-0:52.32.0(00002)");
+  handleString("1-0:72.32.0(00003)");
+  handleString("1-0:32.36.0(00004)");
+  handleString("1-0:52.36.0(00005)");
+  handleString("1-0:72.36.0(00006)");
+  handleString("0-0:96.13.1()");
+  handleString("0-0:96.13.0()");
+  handleString("1-0:31.7.0(003*A)");
+  handleString("1-0:51.7.0(006*A)");
+  handleString("1-0:71.7.0(009*A)");
+  handleString("1-0:21.7.0(00.596*kW)");
+  handleString("1-0:22.7.0(00.091*kW)");
+  handleString("1-0:41.7.0(00.112*kW)");
+  handleString("1-0:42.7.0(00.092*kW)");
+  handleString("1-0:61.7.0(00.002*kW)");
+  handleString("1-0:62.7.0(00.093*kW)");
+  handleString("0-1:24.1.0(003)");
+  handleString("0-1:96.1.0(4730303233353631323233373631313134)");
+  handleString("0-1:24.2.1(210413140000S)(04981.523*m3)");
+  handleString("!ECD2");  
+}
 
 void setup() {
 
@@ -20,113 +112,61 @@ void setup() {
   Serial.begin(115200);
   pinMode(3, FUNCTION_0);
 
-  if (DEBUGE_MODE) {
-    Serial.println("Booting");
-  }
+  logger.info("Booting");
 
   // Setup Wifi
+  wifiConnector = WifiConnector();
   wifiConnector.start();
 
   // Setup MQTT
-  mqqtPublisher.start();
+  mqttPublisher = MQTTPublisher();
+  mqttPublisher.start();
+
+//  test();
 }
 
 void loop() {
   
   wifiConnector.handle();
   yield();
-  mqqtPublisher.handle();
+  mqttPublisher.handle();
   yield();
 
   // If serial received, read until newline
   if (Serial.available() > 0) {
     incomingString = Serial.readStringUntil('\n');
-    handelString(incomingString);
+    handleString(incomingString);
   }
 }
 
 // Regex are not supported, so use indexOf and substring
-void handelString(String incomingString) {
+void handleString(String incomingString) {
 
-  // DSMR version
-  int found1 = incomingString.indexOf("1-3:0.2.8");
-  if (found1 > -1) {
-    String value1 = incomingString.substring(10, 12);
-    if (DEBUGE_MODE)
-      Serial.println("0.2.8= " + value1);
-    mqqtPublisher.publishOnMQTT(MQTT_TOPIC, "/version", value1);
+  int i;
+  int arraySize = sizeof(measurements)/sizeof(measurements[0]);
+  
+  for (i = 0; i < arraySize; i++) {
+    Measurement measurement = measurements[i];
+    String obisKey = measurement.key;
+
+    if(incomingString.indexOf(obisKey) > -1) {
+      // found
+      String value = incomingString.substring(measurement.start, measurement.end);
+      logger.debug("DEBUG_1 " + obisKey + "=" + value);
+      
+      switch (measurement.valueType) {
+        case Measurement::FLOAT:
+          value = String(value.toFloat(), 3);
+          break;
+        case Measurement::INT:
+          value = String(value.toInt());
+          break;
+        default:
+          break;
+      }
+            
+      mqttPublisher.publishOnMQTT(measurement.name, value);
+      //break; // incoming string has been handled. No need to continue. (for now)
+    }
   }
-
-  // Power consuption
-  int found2 = incomingString.indexOf("1-0:1.7.0");
-  if (found2 > -1) {
-    String value2 = String(incomingString.substring(10, 16).toFloat(), 3);
-    if (DEBUGE_MODE)
-      Serial.println("1.7.0= " + value2);
-    mqqtPublisher.publishOnMQTT(MQTT_TOPIC, "/power_consuption", value2);
-  }
-
-  // Power production
-  int found3 = incomingString.indexOf("1-0:2.7.0");
-  if (found3 > -1) {
-    String value3 = String(incomingString.substring(10, 16).toFloat(), 3);
-    if (DEBUGE_MODE)
-      Serial.println("2.7.0= " + value3);
-    mqqtPublisher.publishOnMQTT(MQTT_TOPIC, "/power_production", value3);
-  }
-
-  // Total consuption low
-  int found4 = incomingString.indexOf("1-0:1.8.1");
-  if (found4 > -1) {
-    String value4 = String(incomingString.substring(10, 20).toFloat(), 3);
-    if (DEBUGE_MODE)
-      Serial.println("1.8.1= " + value4);
-    mqqtPublisher.publishOnMQTT(MQTT_TOPIC, "/total_consuption_low", value4);
-  }
-
-  // Total consuption high
-  int found5 = incomingString.indexOf("1-0:1.8.2");
-  if (found5 > -1) {
-    String value5 = String(incomingString.substring(10, 20).toFloat(), 3);
-    if (DEBUGE_MODE)
-      Serial.println("1.8.2= " + value5);
-    mqqtPublisher.publishOnMQTT(MQTT_TOPIC, "/total_consuption_high", value5);
-  }
-
-  // Total production low
-  int found6 = incomingString.indexOf("1-0:2.8.1");
-  if (found6 > -1) {
-    String value6 = String(incomingString.substring(10, 20).toFloat(), 3);
-    if (DEBUGE_MODE)
-      Serial.println("2.8.1= " + value6);
-    mqqtPublisher.publishOnMQTT(MQTT_TOPIC, "/total_production_low", value6);
-  }
-
-  // Total production high
-  int found7 = incomingString.indexOf("1-0:2.8.2");
-  if (found7 > -1) {
-    String value7 = String(incomingString.substring(10, 20).toFloat(), 3);
-    if (DEBUGE_MODE)
-      Serial.println("2.8.2= " + value7);
-    mqqtPublisher.publishOnMQTT(MQTT_TOPIC, "/total_production_high", value7);
-  }
-
-  // Total gas
-  int found8 = incomingString.indexOf("0-1:24.2.1");
-  if (found8 > -1) {
-    String value8 = String(incomingString.substring(26, 35).toFloat(), 3);
-    if (DEBUGE_MODE)
-      Serial.println("24.2.1= " + value8);
-    mqqtPublisher.publishOnMQTT(MQTT_TOPIC, "/total_gas", value8);
-  }
-
-  // Power tariff (1 low, 2 high)
-  int found9 = incomingString.indexOf("0-0:96.14.0");
-  if (found9 > -1) {
-    String value9 = String(incomingString.substring(12, 16).toInt());
-    if (DEBUGE_MODE)
-      Serial.println("96.14.0= " + value9);
-    mqqtPublisher.publishOnMQTT(MQTT_TOPIC, "/power_tariff", value9);
-  }
-
 }


### PR DESCRIPTION
- Reworking parsing of OBIS properties by using a array of measurement structs containing a name (used for topic), OBIS keys, etc.
- Adding additional properties for Kaifa 304 meter.
- Added a Logger component for more concise logging.
- Changed topic structure : TOPIC_PREFIX / <device_id> / <property>. E.g. "esp-dsmr/b18206/power/total_consumption_low"