### PR TITLE
Updated sensors for HomeAssistant 2022.2 

### DIFF
--- a/AutoConfig.cpp
+++ b/AutoConfig.cpp
@@ -1,4 +1,3 @@
-
 #include <ArduinoJson.h>
 #include "MQTTPublisher.h"
 #include "AutoConfig.h"
@@ -42,13 +41,12 @@ void AutoConfig::SendConfig()
     device["manufacturer"] = "Bram2202";
     device["model"] = "ESP-DSMR";
     device["name"] = _identifier;
-    device["sw_version"] = "v1.3.1";
+    device["sw_version"] = "v1.3.1_u3";
 
     // power_consumption
     autoconfPayload["device"] = device.as<JsonObject>();
     autoconfPayload["availability_topic"] = _identifier + "/power/consumption/status";
     autoconfPayload["state_topic"] = _identifier + "/power/consumption";
-    autoconfPayload["last_reset_topic"] = _identifier + "/power/consumption/reset";
     autoconfPayload["name"] = _identifier + "_power_consumption";
     autoconfPayload["unit_of_measurement"] = "kW";
     autoconfPayload["unique_id"] = "power_consumption";
@@ -63,14 +61,12 @@ void AutoConfig::SendConfig()
     autoconfPayload["device"] = device.as<JsonObject>();
     autoconfPayload["availability_topic"] = _identifier + "/power/production/status";
     autoconfPayload["state_topic"] = _identifier + "/power/production";
-    autoconfPayload["last_reset_topic"] = _identifier + "/power/production/reset";
     autoconfPayload["name"] = _identifier + "_power_production";
     autoconfPayload["unit_of_measurement"] = "kW";
     autoconfPayload["unique_id"] = "power_production";
     autoconfPayload["icon"] = "mdi:flash";
     autoconfPayload["device_class"] = "power";
     autoconfPayload["state_class"] = "measurement";
-    autoconfPayload["last_reset_value_template"] = "1970-01-01T00:00:00+00:00";
     serializeJson(autoconfPayload, mqttPayload);
     _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/power_production/config", &mqttPayload[0], false);
     autoconfPayload.clear();
@@ -79,14 +75,12 @@ void AutoConfig::SendConfig()
     autoconfPayload["device"] = device.as<JsonObject>();
     autoconfPayload["availability_topic"] = _identifier + "/power/total_consumption_tariff_1/status";
     autoconfPayload["state_topic"] = _identifier + "/power/total_consumption_tariff_1";
-    autoconfPayload["last_reset_topic"] = _identifier + "/power/total_consumption_tariff_1/reset";
     autoconfPayload["name"] = _identifier + "_total_consumption_tariff_1";
     autoconfPayload["unit_of_measurement"] = "kWh";
     autoconfPayload["unique_id"] = "total_consumption_tariff_1";
     autoconfPayload["icon"] = "mdi:counter";
     autoconfPayload["device_class"] = "energy";
-    autoconfPayload["state_class"] = "measurement";
-    autoconfPayload["last_reset_value_template"] = "1970-01-01T00:00:00+00:00";
+    autoconfPayload["state_class"] = "total_increasing";
     serializeJson(autoconfPayload, mqttPayload);
     _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/total_consumption_tariff_1/config", &mqttPayload[0], false);
     autoconfPayload.clear();
@@ -95,14 +89,12 @@ void AutoConfig::SendConfig()
     autoconfPayload["device"] = device.as<JsonObject>();
     autoconfPayload["availability_topic"] = _identifier + "/power/total_consumption_tariff_2/status";
     autoconfPayload["state_topic"] = _identifier + "/power/total_consumption_tariff_2";
-    autoconfPayload["last_reset_topic"] = _identifier + "/power/total_consumption_tariff_2/reset";
     autoconfPayload["name"] = _identifier + "_total_consumption_tariff_2";
     autoconfPayload["unit_of_measurement"] = "kWh";
     autoconfPayload["unique_id"] = "total_consumption_tariff_2";
     autoconfPayload["icon"] = "mdi:counter";
     autoconfPayload["device_class"] = "energy";
-    autoconfPayload["state_class"] = "measurement";
-    autoconfPayload["last_reset_value_template"] = "1970-01-01T00:00:00+00:00";
+    autoconfPayload["state_class"] = "total_increasing";
     serializeJson(autoconfPayload, mqttPayload);
     _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/total_consumption_tariff_2/config", &mqttPayload[0], false);
     autoconfPayload.clear();
@@ -111,14 +103,12 @@ void AutoConfig::SendConfig()
     autoconfPayload["device"] = device.as<JsonObject>();
     autoconfPayload["availability_topic"] = _identifier + "/power/total_production_tariff_1/status";
     autoconfPayload["state_topic"] = _identifier + "/power/total_production_tariff_1";
-    autoconfPayload["last_reset_topic"] = _identifier + "/power/total_production_tariff_1/reset";
     autoconfPayload["name"] = _identifier + "_total_production_tariff_1";
     autoconfPayload["unit_of_measurement"] = "kWh";
     autoconfPayload["unique_id"] = "total_production_tariff_1";
     autoconfPayload["icon"] = "mdi:counter";
     autoconfPayload["device_class"] = "energy";
-    autoconfPayload["state_class"] = "measurement";
-    autoconfPayload["last_reset_value_template"] = "1970-01-01T00:00:00+00:00";
+    autoconfPayload["state_class"] = "total_increasing";
     serializeJson(autoconfPayload, mqttPayload);
     _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/total_production_tariff_1/config", &mqttPayload[0], false);
     autoconfPayload.clear();
@@ -127,14 +117,12 @@ void AutoConfig::SendConfig()
     autoconfPayload["device"] = device.as<JsonObject>();
     autoconfPayload["availability_topic"] = _identifier + "/power/total_production_tariff_2/status";
     autoconfPayload["state_topic"] = _identifier + "/power/total_production_tariff_2";
-    autoconfPayload["last_reset_topic"] = _identifier + "/power/total_production_tariff_2/reset";
     autoconfPayload["name"] = _identifier + "_total_production_tariff_2";
     autoconfPayload["unit_of_measurement"] = "kWh";
     autoconfPayload["unique_id"] = "total_production_tariff_2";
     autoconfPayload["icon"] = "mdi:counter";
     autoconfPayload["device_class"] = "energy";
-    autoconfPayload["state_class"] = "measurement";
-    autoconfPayload["last_reset_value_template"] = "1970-01-01T00:00:00+00:00";
+    autoconfPayload["state_class"] = "total_increasing";
     serializeJson(autoconfPayload, mqttPayload);
     _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/total_production_tariff_2/config", &mqttPayload[0], false);
     autoconfPayload.clear();
@@ -149,6 +137,150 @@ void AutoConfig::SendConfig()
     _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/power_tariff/config", &mqttPayload[0], false);
     autoconfPayload.clear();
 
+    // Custom stuff here
+    if (AUTOCONFIG_CUSTOM_POWER_EXTENDED)
+    {
+        // total_consumption
+        autoconfPayload["device"] = device.as<JsonObject>();
+        autoconfPayload["availability_topic"] = _identifier + "/power/total_consumption/status";
+        autoconfPayload["state_topic"] = _identifier + "/power/total_consumption";
+        autoconfPayload["name"] = _identifier + "_total_consumption";
+        autoconfPayload["unit_of_measurement"] = "kWh";
+        autoconfPayload["unique_id"] = "total_consumption";
+        autoconfPayload["icon"] = "mdi:counter";
+        autoconfPayload["device_class"] = "energy";
+        autoconfPayload["state_class"] = "total_increasing";
+        serializeJson(autoconfPayload, mqttPayload);
+        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/total_consumption/config", &mqttPayload[0], false);
+        autoconfPayload.clear();
+
+        // total_production
+        autoconfPayload["device"] = device.as<JsonObject>();
+        autoconfPayload["availability_topic"] = _identifier + "/power/total_production/status";
+        autoconfPayload["state_topic"] = _identifier + "/power/total_production";
+        autoconfPayload["name"] = _identifier + "_total_production";
+        autoconfPayload["unit_of_measurement"] = "kWh";
+        autoconfPayload["unique_id"] = "total_production";
+        autoconfPayload["icon"] = "mdi:counter";
+        autoconfPayload["device_class"] = "energy";
+        autoconfPayload["state_class"] = "total_increasing";
+        serializeJson(autoconfPayload, mqttPayload);
+        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/total_production/config", &mqttPayload[0], false);
+        autoconfPayload.clear();
+
+        // total_reactive_consumption
+        autoconfPayload["device"] = device.as<JsonObject>();
+        autoconfPayload["availability_topic"] = _identifier + "/power/total_reactive_consumption/status";
+        autoconfPayload["state_topic"] = _identifier + "/power/total_reactive_consumption";
+        autoconfPayload["name"] = _identifier + "_total_reactive_consumption";
+        autoconfPayload["unit_of_measurement"] = "kWh";
+        autoconfPayload["unique_id"] = "total_reactive_consumption";
+        autoconfPayload["icon"] = "mdi:counter";
+        autoconfPayload["device_class"] = "energy";
+        autoconfPayload["state_class"] = "total_increasing";
+        serializeJson(autoconfPayload, mqttPayload);
+        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/total_reactive_consumption/config", &mqttPayload[0], false);
+        autoconfPayload.clear();
+
+        // total_reactive_production
+        autoconfPayload["device"] = device.as<JsonObject>();
+        autoconfPayload["availability_topic"] = _identifier + "/power/total_reactive_production/status";
+        autoconfPayload["state_topic"] = _identifier + "/power/total_reactive_production";
+        autoconfPayload["name"] = _identifier + "_total_reactive_production";
+        autoconfPayload["unit_of_measurement"] = "kWh";
+        autoconfPayload["unique_id"] = "total_reactive_production";
+        autoconfPayload["icon"] = "mdi:counter";
+        autoconfPayload["device_class"] = "energy";
+        autoconfPayload["state_class"] = "total_increasing";
+        serializeJson(autoconfPayload, mqttPayload);
+        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/total_reactive_production/config", &mqttPayload[0], false);
+        autoconfPayload.clear();
+
+        // instantaneous current phase 1
+        autoconfPayload["device"] = device.as<JsonObject>();
+        autoconfPayload["availability_topic"] = _identifier + "/power/phase_1/instantaneous_current/status";
+        autoconfPayload["state_topic"] = _identifier + "/power/phase_1/instantaneous_current";
+        autoconfPayload["name"] = _identifier + "_phase_1_instantaneous_current";
+        autoconfPayload["unit_of_measurement"] = "A";
+        autoconfPayload["unique_id"] = "phase_1_instantaneous_current";
+        autoconfPayload["icon"] = "mdi:flash";
+        autoconfPayload["device_class"] = "current";
+        autoconfPayload["state_class"] = "measurement";
+        serializeJson(autoconfPayload, mqttPayload);
+        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/phase_1_instantaneous_current/config", &mqttPayload[0], false);
+        autoconfPayload.clear();
+
+        // instantaneous current phase 2
+        autoconfPayload["device"] = device.as<JsonObject>();
+        autoconfPayload["availability_topic"] = _identifier + "/power/phase_2/instantaneous_current/status";
+        autoconfPayload["state_topic"] = _identifier + "/power/phase_2/instantaneous_current";
+        autoconfPayload["name"] = _identifier + "_phase_2_instantaneous_current";
+        autoconfPayload["unit_of_measurement"] = "A";
+        autoconfPayload["unique_id"] = "phase_2_instantaneous_current";
+        autoconfPayload["icon"] = "mdi:flash";
+        autoconfPayload["device_class"] = "current";
+        autoconfPayload["state_class"] = "measurement";
+        serializeJson(autoconfPayload, mqttPayload);
+        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/phase_2_instantaneous_current/config", &mqttPayload[0], false);
+        autoconfPayload.clear();
+
+        // instantaneous current phase 3
+        autoconfPayload["device"] = device.as<JsonObject>();
+        autoconfPayload["availability_topic"] = _identifier + "/power/phase_3/instantaneous_current/status";
+        autoconfPayload["state_topic"] = _identifier + "/power/phase_3/instantaneous_current";
+        autoconfPayload["name"] = _identifier + "_phase_3_instantaneous_current";
+        autoconfPayload["unit_of_measurement"] = "A";
+        autoconfPayload["unique_id"] = "phase_3_instantaneous_current";
+        autoconfPayload["icon"] = "mdi:flash";
+        autoconfPayload["device_class"] = "current";
+        autoconfPayload["state_class"] = "measurement";
+        serializeJson(autoconfPayload, mqttPayload);
+        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/phase_3_instantaneous_current/config", &mqttPayload[0], false);
+        autoconfPayload.clear();
+
+        // instantaneous voltage phase 1
+        autoconfPayload["device"] = device.as<JsonObject>();
+        autoconfPayload["availability_topic"] = _identifier + "/power/phase_1/instantaneous_voltage/status";
+        autoconfPayload["state_topic"] = _identifier + "/power/phase_1/instantaneous_voltage";
+        autoconfPayload["name"] = _identifier + "_phase_1_instantaneous_voltage";
+        autoconfPayload["unit_of_measurement"] = "V";
+        autoconfPayload["unique_id"] = "phase_1_instantaneous_voltage";
+        autoconfPayload["icon"] = "mdi:flash";
+        autoconfPayload["device_class"] = "voltage";
+        autoconfPayload["state_class"] = "measurement";
+        serializeJson(autoconfPayload, mqttPayload);
+        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/phase_1_instantaneous_voltage/config", &mqttPayload[0], false);
+        autoconfPayload.clear();
+
+        // instantaneous voltage phase 2
+        autoconfPayload["device"] = device.as<JsonObject>();
+        autoconfPayload["availability_topic"] = _identifier + "/power/phase_2/instantaneous_voltage/status";
+        autoconfPayload["state_topic"] = _identifier + "/power/phase_2/instantaneous_voltage";
+        autoconfPayload["name"] = _identifier + "_phase_2_instantaneous_voltage";
+        autoconfPayload["unit_of_measurement"] = "V";
+        autoconfPayload["unique_id"] = "phase_2_instantaneous_voltage";
+        autoconfPayload["icon"] = "mdi:flash";
+        autoconfPayload["device_class"] = "voltage";
+        autoconfPayload["state_class"] = "measurement";
+        serializeJson(autoconfPayload, mqttPayload);
+        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/phase_2_instantaneous_voltage/config", &mqttPayload[0], false);
+        autoconfPayload.clear();
+
+        // instantaneous voltage phase 3
+        autoconfPayload["device"] = device.as<JsonObject>();
+        autoconfPayload["availability_topic"] = _identifier + "/power/phase_3/instantaneous_voltage/status";
+        autoconfPayload["state_topic"] = _identifier + "/power/phase_3/instantaneous_voltage";
+        autoconfPayload["name"] = _identifier + "_phase_3_instantaneous_voltage";
+        autoconfPayload["unit_of_measurement"] = "V";
+        autoconfPayload["unique_id"] = "phase_3_instantaneous_voltage";
+        autoconfPayload["icon"] = "mdi:flash";
+        autoconfPayload["device_class"] = "voltage";
+        autoconfPayload["state_class"] = "measurement";
+        serializeJson(autoconfPayload, mqttPayload);
+        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/phase_3_instantaneous_voltage/config", &mqttPayload[0], false);
+        autoconfPayload.clear();
+    }
+
     // Extra stuff here
     if (AUTOCONFIG_POWER_EXTENDED)
     {
@@ -156,7 +288,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/short_power_outages/status";
         autoconfPayload["state_topic"] = _identifier + "/power/short_power_outages";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/short_power_outages/reset";
         autoconfPayload["name"] = _identifier + "_short_power_outages";
         autoconfPayload["unique_id"] = "short_power_outages";
         autoconfPayload["icon"] = "mdi:flash-off";
@@ -168,7 +299,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/long_power_outages/status";
         autoconfPayload["state_topic"] = _identifier + "/power/long_power_outages";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/long_power_outages/reset";
         autoconfPayload["name"] = _identifier + "_long_power_outages";
         autoconfPayload["unique_id"] = "long_power_outages";
         autoconfPayload["icon"] = "mdi:flash-off";
@@ -180,7 +310,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_1/current/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_1/current";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_1/current/reset";
         autoconfPayload["name"] = _identifier + "_phase_1_current";
         autoconfPayload["unit_of_measurement"] = "A";
         autoconfPayload["unique_id"] = "phase_1_current";
@@ -195,7 +324,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_2/current/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_2/current";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_2/current/reset";
         autoconfPayload["name"] = _identifier + "_phase_2_current";
         autoconfPayload["unit_of_measurement"] = "A";
         autoconfPayload["unique_id"] = "phase_2_current";
@@ -210,7 +338,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_3/current/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_3/current";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_3/current/reset";
         autoconfPayload["name"] = _identifier + "_phase_3_current";
         autoconfPayload["unit_of_measurement"] = "A";
         autoconfPayload["unique_id"] = "phase_3_current";
@@ -225,7 +352,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_1/consumption/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_1/consumption";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_1/consumption/reset";
         autoconfPayload["name"] = _identifier + "_phase_1_consumption";
         autoconfPayload["unit_of_measurement"] = "kW";
         autoconfPayload["unique_id"] = "phase_1_consumption";
@@ -240,7 +366,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_2/consumption/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_2/consumption";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_2/consumption/reset";
         autoconfPayload["name"] = _identifier + "_phase_2_consumption";
         autoconfPayload["unit_of_measurement"] = "kW";
         autoconfPayload["unique_id"] = "phase_2_consumption";
@@ -255,7 +380,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_3/consumption/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_3/consumption";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_3/consumption/reset";
         autoconfPayload["name"] = _identifier + "_phase_3_consumption";
         autoconfPayload["unit_of_measurement"] = "kW";
         autoconfPayload["unique_id"] = "phase_3_consumption";
@@ -270,7 +394,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_1/production/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_1/production";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_1/production/reset";
         autoconfPayload["name"] = _identifier + "_phase_1_production";
         autoconfPayload["unit_of_measurement"] = "kW";
         autoconfPayload["unique_id"] = "phase_1_production";
@@ -285,7 +408,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_2/production/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_2/production";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_2/production/reset";
         autoconfPayload["name"] = _identifier + "_phase_2_production";
         autoconfPayload["unit_of_measurement"] = "kW";
         autoconfPayload["unique_id"] = "phase_2_production";
@@ -300,7 +422,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_3/production/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_3/production";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_3/production/reset";
         autoconfPayload["name"] = _identifier + "_phase_3_production";
         autoconfPayload["unit_of_measurement"] = "kW";
         autoconfPayload["unique_id"] = "phase_3_production";
@@ -315,7 +436,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_1/drops/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_1/drops";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_1/drops/reset";
         autoconfPayload["name"] = _identifier + "_phase_1_drops";
         autoconfPayload["unique_id"] = "phase_1_drops";
         autoconfPayload["icon"] = "mdi:chart-sankey";
@@ -327,7 +447,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_2/drops/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_2/drops";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_2/drops/reset";
         autoconfPayload["name"] = _identifier + "_phase_2_drops";
         autoconfPayload["unique_id"] = "phase_2_drops";
         autoconfPayload["icon"] = "mdi:chart-sankey";
@@ -339,7 +458,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_3/drops/status";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_3/drops";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_3/drops/reset";
         autoconfPayload["name"] = _identifier + "_phase_3_drops";
         autoconfPayload["unique_id"] = "phase_3_drops";
         autoconfPayload["icon"] = "mdi:chart-sankey";
@@ -351,7 +469,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_1/drops/peaks";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_1/peaks";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_1/peaks/reset";
         autoconfPayload["name"] = _identifier + "_phase_1_peaks";
         autoconfPayload["unique_id"] = "phase_1_peaks";
         autoconfPayload["icon"] = "mdi:chart-bell-curve";
@@ -363,7 +480,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_2/drops/peaks";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_2/peaks";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_2/peaks/reset";
         autoconfPayload["name"] = _identifier + "_phase_2_peaks";
         autoconfPayload["unique_id"] = "phase_2_peaks";
         autoconfPayload["icon"] = "mdi:chart-bell-curve";
@@ -375,7 +491,6 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/power/phase_3/drops/peaks";
         autoconfPayload["state_topic"] = _identifier + "/power/phase_3/peaks";
-        autoconfPayload["last_reset_topic"] = _identifier + "/power/phase_3/peaks/reset";
         autoconfPayload["name"] = _identifier + "_phase_3_peaks";
         autoconfPayload["unique_id"] = "phase_3_peaks";
         autoconfPayload["icon"] = "mdi:chart-bell-curve";
@@ -390,14 +505,12 @@ void AutoConfig::SendConfig()
         autoconfPayload["device"] = device.as<JsonObject>();
         autoconfPayload["availability_topic"] = _identifier + "/gas/total/status";
         autoconfPayload["state_topic"] = _identifier + "/gas/total";
-        autoconfPayload["last_reset_topic"] = _identifier + "/gas/total/reset";
         autoconfPayload["name"] = _identifier + "_total_gas";
         autoconfPayload["unit_of_measurement"] = "m³";
         autoconfPayload["unique_id"] = "gas_total";
         autoconfPayload["icon"] = "mdi:counter";
-        autoconfPayload["last_reset_value_template"] = "1970-01-01T00:00:00+00:00";
         serializeJson(autoconfPayload, mqttPayload);
-        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/total_gas/config", &mqttPayload[0], false);
+        _mqttPublisher.publish("homeassistant/sensor/" + _identifier + "/gas_total/config", &mqttPayload[0], false);
         autoconfPayload.clear();
     }
 }

--- a/Settings.example.h
+++ b/Settings.example.h
@@ -25,5 +25,8 @@
 // Setup all power entities in HA
 #define AUTOCONFIG_POWER_EXTENDED true
 
+// Setup all custom entities in HA
+#define AUTOCONFIG_CUSTOM_POWER_EXTENDED true
+
 //for debugging, print info on serial (DEBUG, INFO, WARN)
 #define LOG_LEVEL INFO

--- a/esp8266-dsmr.ino
+++ b/esp8266-dsmr.ino
@@ -32,9 +32,9 @@ typedef struct
 const Measurement measurements[] = {
     {"version", "1-3:0.2.8", 10, 12, false, Measurement::STRING},
     {"power/timestamp", "0-0:1.0.0", 10, 23, false, Measurement::STRING},
-    {"power/device_id", "0-0:96.1.1", 11, 45, false, Measurement::STRING},
-    {"power/consumption", "1-0:1.7.0", 10, 16, false, Measurement::FLOAT},
-    {"power/production", "1-0:2.7.0", 10, 16, false, Measurement::FLOAT},
+    {"power/device_id", "0-0:96.1.1", 11, 26, false, Measurement::STRING},
+    {"power/consumption", "1-0:1.7.0", 10, 20, false, Measurement::FLOAT},
+    {"power/production", "1-0:2.7.0", 10, 20, false, Measurement::FLOAT},
     {"power/total_consumption_tariff_1", "1-0:1.8.1", 10, 20, false, Measurement::FLOAT},
     {"power/total_consumption_tariff_2", "1-0:1.8.2", 10, 20, false, Measurement::FLOAT},
     {"power/total_production_tariff_1", "1-0:2.8.1", 10, 20, false, Measurement::FLOAT},
@@ -57,6 +57,16 @@ const Measurement measurements[] = {
     {"power/phase_1/production", "1-0:22.7.0", 11, 17, false, Measurement::FLOAT},
     {"power/phase_2/production", "1-0:42.7.0", 11, 17, false, Measurement::FLOAT},
     {"power/phase_3/production", "1-0:62.7.0", 11, 17, false, Measurement::FLOAT},
+    {"power/total_consumption", "1-0:1.8.0", 10, 20, false, Measurement::FLOAT},
+    {"power/total_production", "1-0:2.8.0", 10, 20, false, Measurement::FLOAT},
+    {"power/total_reactive_consumption", "1-0:3.8.0", 10, 20, false, Measurement::FLOAT},
+    {"power/total_reactive_production", "1-0:4.8.0", 10, 20, false, Measurement::FLOAT},
+    {"power/phase_1/instantaneous_voltage", "1-0:32.7.0", 11, 16, false, Measurement::FLOAT},
+    {"power/phase_2/instantaneous_voltage", "1-0:52.7.0", 11, 16, false, Measurement::FLOAT},
+    {"power/phase_3/instantaneous_voltage", "1-0:72.7.0", 11, 16, false, Measurement::FLOAT},
+    {"power/phase_1/instantaneous_current", "1-0:31.7.0", 11, 14, false, Measurement::INT},
+    {"power/phase_2/instantaneous_current", "1-0:51.7.0", 11, 14, false, Measurement::INT},
+    {"power/phase_3/instantaneous_current", "1-0:71.7.0", 11, 14, false, Measurement::INT},
     {"gas/total", "0-1:24.2.1", 26, 35, false, Measurement::FLOAT},
     {"gas/device_id", "0-1:96.1.0", 11, 45, false, Measurement::STRING},
     {"gas/timestamp", "0-1:24.2.1", 11, 24, false, Measurement::STRING}};
@@ -156,12 +166,11 @@ void handleString(String incomingString)
         break;
       }
 
-      // Check if measurement state is offline, if so publish online state and last reset
+      // Check if measurement state is offline, if so publish online state
       if (!measurement.online)
       {
         measurement.online = true;
         mqttPublisher.publish(measurement.name + "/status", "online", true);
-        mqttPublisher.publish(measurement.name + "/reset", "1970-01-01T00:00:00+00:00", true);
       }
 
       // Publish measurement


### PR DESCRIPTION
 Since w3host never asked for a pull request, 

Forgot to add the settings page for w3host his custom settings

Updated sensors for HomeAssistant 2022.2

- Removed last_reset_topic
- Removed last_reset_value_template
- Update state_classes
- Added Gas Fix